### PR TITLE
reCAPTCHA v2: add support for verifying hostname and action, retreiving full response, and add Cloudflare Turnstile constants and fields

### DIFF
--- a/BitArmory.ReCaptcha.Tests/BitArmory.ReCaptcha.Tests.csproj
+++ b/BitArmory.ReCaptcha.Tests/BitArmory.ReCaptcha.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net45;netcoreapp3.1;net6.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/BitArmory.ReCaptcha.Tests/BitArmory.ReCaptcha.Tests.csproj
+++ b/BitArmory.ReCaptcha.Tests/BitArmory.ReCaptcha.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net45;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1;net6.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/BitArmory.ReCaptcha.Tests/CaptchaVersion2Tests.cs
+++ b/BitArmory.ReCaptcha.Tests/CaptchaVersion2Tests.cs
@@ -21,6 +21,21 @@ namespace BitArmory.ReCaptcha.Tests
          return json;
       }
 
+      string ResponseJsonWithHostAndAction(bool isSuccess, string hostname, string action)
+      {
+         var json = @"{
+  ""success"": {SUCCESS},
+  ""challenge_ts"": ""2018-05-15T23:05:22Z"",
+  ""hostname"": ""{HOSTNAME}"",
+  ""action"": ""{ACTION}""
+}"
+         .Replace("{SUCCESS}", isSuccess.ToString().ToLower())
+         .Replace("{HOSTNAME}", hostname)
+         .Replace("{ACTION}", action);
+
+         return json;
+      }
+
       [Test]
       public async Task can_verify_a_captcha()
       {
@@ -57,6 +72,82 @@ namespace BitArmory.ReCaptcha.Tests
          var response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc");
 
          response.Should().BeFalse();
+
+         mockHttp.VerifyNoOutstandingExpectation();
+      }
+
+      [Test]
+      public async Task can_verify_a_captcha_from_another_url()
+      {
+         var responseJson = ResponseJson(true);
+
+         var mockHttp = new MockHttpMessageHandler();
+
+         mockHttp.Expect(HttpMethod.Post, Constants.TurnstileVerifyUrl)
+            .Respond("application/json", responseJson)
+            .WithExactFormData("response=aaaaa&remoteip=bbbb&secret=cccc");
+
+         var captcha = new ReCaptchaService(Constants.TurnstileVerifyUrl, client: mockHttp.ToHttpClient());
+
+         var response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc");
+
+         response.Should().BeTrue();
+
+         mockHttp.VerifyNoOutstandingExpectation();
+      }
+
+      [Test]
+      public async Task can_verify_a_captcha_with_hostname_and_action()
+      {
+         var responseJson = ResponseJson(true);
+         var mockHttp = new MockHttpMessageHandler();
+         mockHttp.When(HttpMethod.Post, Constants.TurnstileVerifyUrl)
+            .Respond("application/json", responseJson)
+            .WithExactFormData("response=aaaaa&remoteip=bbbb&secret=cccc");
+         var captcha = new ReCaptchaService(Constants.TurnstileVerifyUrl, client: mockHttp.ToHttpClient());
+
+         var response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc", hostname: "localhost");
+         response.Should().BeTrue();
+
+         response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc", hostname: "not-localhost");
+         response.Should().BeFalse();
+
+         response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc", hostname: "not-localhost", action: "test");
+         response.Should().BeFalse();
+
+         response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc", hostname: "localhost", action: "test");
+         response.Should().BeFalse();
+
+         mockHttp.VerifyNoOutstandingExpectation();
+
+         // Now generate responses with the action field filled out (and a different hostname)
+         responseJson = ResponseJsonWithHostAndAction(true, "example.com", "test-action");
+         mockHttp = new MockHttpMessageHandler();
+         mockHttp.When(HttpMethod.Post, Constants.TurnstileVerifyUrl)
+            .Respond("application/json", responseJson)
+            .WithExactFormData("response=aaaaa&remoteip=bbbb&secret=cccc");
+         captcha = new ReCaptchaService(Constants.TurnstileVerifyUrl, client: mockHttp.ToHttpClient());
+
+         response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc", hostname: "localhost", action: "test-action");
+         response.Should().BeFalse();
+
+         response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc", hostname: "example.com", action: "test-action");
+         response.Should().BeTrue();
+
+         response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc", hostname: "example.com", action: "action");
+         response.Should().BeFalse();
+
+         response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc", hostname: "example.com");
+         response.Should().BeTrue();
+
+         response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc", action: "example.com");
+         response.Should().BeFalse();
+
+         response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc", action: "test-action");
+         response.Should().BeTrue();
+
+         response = await captcha.Verify2Async("aaaaa", "bbbb", "cccc");
+         response.Should().BeTrue();
 
          mockHttp.VerifyNoOutstandingExpectation();
       }

--- a/BitArmory.ReCaptcha/BitArmory.ReCaptcha.csproj
+++ b/BitArmory.ReCaptcha/BitArmory.ReCaptcha.csproj
@@ -5,7 +5,7 @@
     </PackageReleaseNotes>
     <Version>0.0.0-localbuild</Version>
     <Authors>Brian Chavez</Authors>
-    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <CodeAnalysisRuleSet>BitArmory.ReCaptcha.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -14,7 +14,7 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyName>BitArmory.ReCaptcha</AssemblyName>
     <PackageId>BitArmory.ReCaptcha</PackageId>
-    <PackageTags>google;recaptcha;captcha;asp.net;aspnet;mvc;core;razor;razorpages;webforms;security;bot;anti-spam;validation;recpatcha</PackageTags>
+    <PackageTags>google;recaptcha;captcha;cloudflare;turnstile;asp.net;aspnet;mvc;core;razor;razorpages;webforms;security;bot;anti-spam;validation;recpatcha</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/BitArmory/ReCaptcha/master/docs/recaptcha.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/BitArmory/ReCaptcha</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/BitArmory/ReCaptcha/master/LICENSE</PackageLicenseUrl>

--- a/BitArmory.ReCaptcha/Constants.cs
+++ b/BitArmory.ReCaptcha/Constants.cs
@@ -11,13 +11,33 @@
       public const string VerifyUrl = "https://www.google.com/recaptcha/api/siteverify";
 
       /// <summary>
-      /// Default URL for reCAPTCHA.js
+      /// Default URL for verifying reCAPTCHA.
+      /// </summary>
+      public const string TurnstileVerifyUrl = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+      /// <summary>
+      /// Default JavaScript URL for reCAPTCHA.js
       /// </summary>
       public const string JavaScriptUrl = "https://www.google.com/recaptcha/api.js";
 
-      /// <summary>  
+      /// <summary>
+      /// More available JavaScript URL for reCAPTCHA.js (available where google.com isn't)
+      /// </summary>
+      public const string NonGoogleJavaScriptUrl = "https://www.recaptcha.net/recaptcha/api.js";
+
+      /// <summary>
+      /// Default JavaScript URL for Cloudflare Turnstile
+      /// </summary>
+      public const string TurnstileJavaScriptUrl = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+
+      /// <summary>
       /// Default HTTP header key for reCAPTCHA response.
       /// </summary>
       public const string ClientResponseKey = "g-recaptcha-response";
+
+      /// <summary>
+      /// Default HTTP header key for reCAPTCHA response.
+      /// </summary>
+      public const string TurnstileClientResponseKey = "cf-turnstile-response";
    }
 }

--- a/BitArmory.ReCaptcha/ReCaptchaResponse.cs
+++ b/BitArmory.ReCaptcha/ReCaptchaResponse.cs
@@ -14,7 +14,55 @@ namespace BitArmory.ReCaptcha
    }
    
    /// <summary>
-   /// Response from reCAPTCHA verify URL.
+   /// Response from reCAPTCHA v2 or Cloudflare Turnstile verify URL.
+   /// </summary>
+   public class ReCaptcha2Response : JsonResponse
+   {
+      /// <summary>
+      /// Whether this request was a valid reCAPTCHA token for your site.
+      /// </summary>
+      public bool IsSuccess { get; set; }
+
+      /// <summary>
+      /// The action name for this request, only provided by Cloudflare Turnstile, not reCAPTCHA v2 (important to verify).
+      /// </summary>
+      public string? Action { get; set; }
+
+      /// <summary>
+      /// Timestamp of the challenge load (ISO format yyyy-MM-dd'T'HH:mm:ssZZ).
+      /// </summary>
+      public string ChallengeTs { get; set; }
+
+      /// <summary>
+      /// missing-input-secret: The secret parameter is missing.
+      /// invalid-input-secret: The secret parameter is invalid or malformed.
+      /// missing-input-response: The response parameter is missing.
+      /// invalid-input-response: The response parameter is invalid or malformed.
+      /// bad-request: The request is invalid or malformed.
+      /// timeout-or-duplicate: The response is no longer valid: either is too old or has been used previously.
+      /// </summary>
+      public string[] ErrorCodes { get; set; }
+
+      /// <summary>
+      /// The hostname of the site where the reCAPTCHA was solved (if solved on a website).
+      /// </summary>
+      public string? HostName { get; set; }
+
+      /// <summary>
+      /// ApkPackageName is the package name of the app the captcha was solved on (if solved in an android app).
+      /// </summary>
+      public string? ApkPackageName { get; set; }
+
+      /// <summary>
+      /// Customer data passed on the client side.
+      ///
+      /// Only provided by Cloudflare Turnstile, not reCAPTCHA v2.
+      /// </summary>
+      public string? CData { get; set; }
+   }
+   
+   /// <summary>
+   /// Response from reCAPTCHA v3 verify URL.
    /// </summary>
    public class ReCaptcha3Response : JsonResponse
    {
@@ -49,9 +97,14 @@ namespace BitArmory.ReCaptcha
       public string[] ErrorCodes { get; set; }
 
       /// <summary>
-      /// The hostname of the site where the reCAPTCHA was solved
+      /// The hostname of the site where the reCAPTCHA was solved (if solved on a website).
       /// </summary>
-      public string HostName { get; set; }
+      public string? HostName { get; set; }
+
+      /// <summary>
+      /// ApkPackageName is the package name of the app the captcha was solved on (if solved in an android app).
+      /// </summary>
+      public string? ApkPackageName { get; set; }
    }
 
 }

--- a/BitArmory.ReCaptcha/ReCaptchaResponse.cs
+++ b/BitArmory.ReCaptcha/ReCaptchaResponse.cs
@@ -26,7 +26,7 @@ namespace BitArmory.ReCaptcha
       /// <summary>
       /// The action name for this request, only provided by Cloudflare Turnstile, not reCAPTCHA v2 (important to verify).
       /// </summary>
-      public string? Action { get; set; }
+      public string Action { get; set; }
 
       /// <summary>
       /// Timestamp of the challenge load (ISO format yyyy-MM-dd'T'HH:mm:ssZZ).
@@ -46,19 +46,19 @@ namespace BitArmory.ReCaptcha
       /// <summary>
       /// The hostname of the site where the reCAPTCHA was solved (if solved on a website).
       /// </summary>
-      public string? HostName { get; set; }
+      public string HostName { get; set; }
 
       /// <summary>
       /// ApkPackageName is the package name of the app the captcha was solved on (if solved in an android app).
       /// </summary>
-      public string? ApkPackageName { get; set; }
+      public string ApkPackageName { get; set; }
 
       /// <summary>
       /// Customer data passed on the client side.
       ///
       /// Only provided by Cloudflare Turnstile, not reCAPTCHA v2.
       /// </summary>
-      public string? CData { get; set; }
+      public string CData { get; set; }
    }
    
    /// <summary>
@@ -99,12 +99,12 @@ namespace BitArmory.ReCaptcha
       /// <summary>
       /// The hostname of the site where the reCAPTCHA was solved (if solved on a website).
       /// </summary>
-      public string? HostName { get; set; }
+      public string HostName { get; set; }
 
       /// <summary>
       /// ApkPackageName is the package name of the app the captcha was solved on (if solved in an android app).
       /// </summary>
-      public string? ApkPackageName { get; set; }
+      public string ApkPackageName { get; set; }
    }
 
 }

--- a/BitArmory.ReCaptcha/ReCaptchaService.cs
+++ b/BitArmory.ReCaptcha/ReCaptchaService.cs
@@ -46,14 +46,14 @@ namespace BitArmory.ReCaptcha
       }
 
       /// <summary>
-      /// Validate reCAPTCHA v2 <paramref name="clientToken"/> using your secret.
+      /// Validate reCAPTCHA v2 <paramref name="clientToken"/> and return the json response (for internal use).
       /// </summary>
       /// <param name="clientToken">Required. The user response token provided by the reCAPTCHA client-side integration on your site. The <seealso cref="Constants.ClientResponseKey"/> value pulled from the client with the request headers or hidden form field.</param>
-      /// <param name="remoteIp">Optional. The remote IP of the client</param>
+      /// <param name="remoteIp">Optional. The remote IP of the client.</param>
       /// <param name="siteSecret">Required. The server-side secret: v2 secret, invisible secret, or android secret. The shared key between your site and reCAPTCHA.</param>
       /// <param name="cancellationToken">Async cancellation token.</param>
-      /// <returns>Task returning bool whether reCAPTHCA is valid or not.</returns>
-      public virtual async Task<bool> Verify2Async(string clientToken, string remoteIp, string siteSecret, CancellationToken cancellationToken = default)
+      /// <returns>Task returning the parsed JSON response, or null if the request wasn't successful.</returns>
+      async Task<JsonNode?> JsonResponse2Async(string clientToken, string remoteIp, string siteSecret, CancellationToken cancellationToken = default)
       {
          if (string.IsNullOrWhiteSpace(siteSecret)) throw new ArgumentException("The secret must not be null or empty", nameof(siteSecret));
          if (string.IsNullOrWhiteSpace(clientToken)) throw new ArgumentException("The client response must not be null or empty", nameof(clientToken));
@@ -63,13 +63,93 @@ namespace BitArmory.ReCaptcha
          var response = await this.HttpClient.PostAsync(verifyUrl, form, cancellationToken)
             .ConfigureAwait(false);
 
-         if( !response.IsSuccessStatusCode ) return false;
+         if( !response.IsSuccessStatusCode ) return null;
 
          var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-         var model = Json.Parse(json);
+         return Json.Parse(json);
+      }
 
+      /// <summary>
+      /// Validate reCAPTCHA v2 <paramref name="clientToken"/> using your secret.
+      /// </summary>
+      /// <param name="clientToken">Required. The user response token provided by the reCAPTCHA client-side integration on your site. The <seealso cref="Constants.ClientResponseKey"/> value pulled from the client with the request headers or hidden form field.</param>
+      /// <param name="remoteIp">Optional. The remote IP of the client.</param>
+      /// <param name="siteSecret">Required. The server-side secret: v2 secret, invisible secret, or android secret. The shared key between your site and reCAPTCHA.</param>
+      /// <param name="cancellationToken">Async cancellation token.</param>
+      /// <param name="hostname">Optional. The expected hostname. If not null, the verification will fail if this does not match.</param>
+      /// <param name="action">Optional. The expected action (for Cloudflare Turnstile, this should be null if reCAPTCHA v2 is being used). If not null, the verification will fail if this does not match.</param>
+      /// <returns>Task returning bool whether reCAPTHCA is valid or not.</returns>
+      public virtual async Task<bool> Verify2Async(string clientToken, string remoteIp, string siteSecret, CancellationToken cancellationToken = default, string hostname = null, string action = null)
+      {
+         var model = await JsonResponse2Async(clientToken, remoteIp, siteSecret, cancellationToken).ConfigureAwait(false);
+
+         // Check the request was successful
+         if( model == null ) return false;
+
+         // Verify the hostname if it's not null
+         if (hostname != null && hostname != model["hostname"]) return false;
+
+         // Verify the action if it's not null
+         if (action != null && action != model["action"]) return false;
+
+         // Now return the success value
          return model["success"].AsBool;
+      }
+
+      /// <summary>
+      /// Validate reCAPTCHA v2 <paramref name="clientToken"/> using your secret and return the full response.
+      /// </summary>
+      /// <param name="clientToken">Required. The user response token provided by the reCAPTCHA client-side integration on your site. The <seealso cref="Constants.ClientResponseKey"/> value pulled from the client with the request headers or hidden form field.</param>
+      /// <param name="remoteIp">Optional. The remote IP of the client</param>
+      /// <param name="siteSecret">Required. The server-side secret: v2 secret, invisible secret, or android secret. The shared key between your site and reCAPTCHA.</param>
+      /// <param name="cancellationToken">Async cancellation token.</param>
+      /// <returns>Task returning the full response.</returns>
+      public virtual async Task<ReCaptcha2Response> Response2Async(string clientToken, string remoteIp, string siteSecret, CancellationToken cancellationToken = default)
+      {
+         var model = await JsonResponse2Async(clientToken, remoteIp, siteSecret, cancellationToken).ConfigureAwait(false);
+
+         if( model == null ) return new ReCaptcha2Response {IsSuccess = false};
+
+         var result = new ReCaptcha2Response();
+
+         foreach( var kv in model )
+         {
+            switch( kv.Key )
+            {
+               case "success":
+                  result.IsSuccess = kv.Value;
+                  break;
+               case "action":
+                  result.Action = kv.Value;
+                  break;
+               case "challenge_ts":
+                  result.ChallengeTs = kv.Value;
+                  break;
+               case "hostname":
+                  result.HostName = kv.Value;
+                  break;
+               case "apk_package_name":
+                  result.ApkPackageName = kv.Value;
+                  break;
+               case "cdata":
+                  result.CData = kv.Value;
+                  break;
+               case "error-codes" when kv.Value is JsonArray errors:
+               {
+                  result.ErrorCodes = errors.Children
+                     .Select(n => (string)n)
+                     .ToArray();
+
+                  break;
+               }
+               default:
+                  result.ExtraJson.Add(kv.Key, kv.Value);
+                  break;
+            }
+         }
+
+         return result;
       }
 
       /// <summary>
@@ -83,7 +163,6 @@ namespace BitArmory.ReCaptcha
       {
          if( string.IsNullOrWhiteSpace(siteSecret) ) throw new ArgumentException("The secret must not be null or empty", nameof(siteSecret));
          if( string.IsNullOrWhiteSpace(clientToken) ) throw new ArgumentException("The client response must not be null or empty", nameof(clientToken));
-
 
          var form = PrepareRequestBody(clientToken, siteSecret, remoteIp);
 
@@ -116,6 +195,9 @@ namespace BitArmory.ReCaptcha
                   break;
                case "hostname":
                   result.HostName = kv.Value;
+                  break;
+               case "apk_package_name":
+                  result.ApkPackageName = kv.Value;
                   break;
                case "error-codes" when kv.Value is JsonArray errors:
                {

--- a/BitArmory.ReCaptcha/ReCaptchaService.cs
+++ b/BitArmory.ReCaptcha/ReCaptchaService.cs
@@ -53,7 +53,7 @@ namespace BitArmory.ReCaptcha
       /// <param name="siteSecret">Required. The server-side secret: v2 secret, invisible secret, or android secret. The shared key between your site and reCAPTCHA.</param>
       /// <param name="cancellationToken">Async cancellation token.</param>
       /// <returns>Task returning the parsed JSON response, or null if the request wasn't successful.</returns>
-      async Task<JsonNode?> JsonResponse2Async(string clientToken, string remoteIp, string siteSecret, CancellationToken cancellationToken = default)
+      async Task<JsonNode> JsonResponse2Async(string clientToken, string remoteIp, string siteSecret, CancellationToken cancellationToken = default)
       {
          if (string.IsNullOrWhiteSpace(siteSecret)) throw new ArgumentException("The secret must not be null or empty", nameof(siteSecret));
          if (string.IsNullOrWhiteSpace(clientToken)) throw new ArgumentException("The client response must not be null or empty", nameof(clientToken));

--- a/README.md
+++ b/README.md
@@ -259,6 +259,27 @@ That's it! **Happy verifying!** :tada:
 
 After following the [instructions](https://developers.cloudflare.com/turnstile/get-started/) to get the client ready, and to generate your secret key, verifying the resposne on the server side is easy.
 
+#### Client Side
+
+More detailed instructions, including theming, can be found at
+[https://developers.cloudflare.com/turnstile/get-started/](https://developers.cloudflare.com/turnstile/get-started/).
+
+In short, you want to include the JavaScript in the `<head>`:
+
+```html
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+```
+
+And then insert the widget:
+
+```html
+<div class="cf-turnstile" data-sitekey="your-sitekey" data-action="example-action"></div>
+```
+
+The *data-action* attribute can be verified later, on the server side.
+
+#### Server Side
+
 ```csharp
 // 1. Get the client IP address in your chosen web framework
 string clientIp = GetClientIpAddress();
@@ -284,9 +305,17 @@ else{
 }
 ```
 
-The full response, including `cdata`, can be fetched using `captchaApi.Response2Async(capthcaResponse, clientIp, secret)`.
+The *hostname* and *action* can be (and **should** be) verified by passing the `hostname` and `action` arguments to `captchaApi.Verify2Async`, for example:
 
-Furthermore, the *hostname* and *action* can be (and **should** be) verified by passing the `hostname` and `action` arguments to `captchaApi.Verify2Async`.
+```csharp
+var isValid = await captchaApi.Verify2Async(
+    capthcaResponse, clientIp, secret,
+    hostname: "expected.hostname",
+    action: "example-action",
+);
+```
+
+The full response, including `cdata`, can be fetched using `captchaApi.Response2Async(capthcaResponse, clientIp, secret)`.
 
 
 Building

--- a/README.md
+++ b/README.md
@@ -253,13 +253,13 @@ public string GetClientIpAddress(){
 
 That's it! **Happy verifying!** :tada:
 
-### Cloudflare Turnstile
+## Cloudflare Turnstile
 
 [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/) is an alternative to reCAPTCHA, providing a very similar interface to reCAPTCHA v2, which doesn't require user intereaction unless the visitor is suspected of being a bot.
 
 After following the [instructions](https://developers.cloudflare.com/turnstile/get-started/) to get the client ready, and to generate your secret key, verifying the resposne on the server side is easy.
 
-#### Client Side
+### Client Side
 
 More detailed instructions, including theming, can be found at
 [https://developers.cloudflare.com/turnstile/get-started/](https://developers.cloudflare.com/turnstile/get-started/).
@@ -278,7 +278,7 @@ And then insert the widget:
 
 The *data-action* attribute can be verified later, on the server side.
 
-#### Server Side
+### Server Side
 
 ```csharp
 // 1. Get the client IP address in your chosen web framework


### PR DESCRIPTION
This PR:

- Adds `net6.0` to the list of target frameworks,
- Adds the `ReCaptcha2Response` class for retrieving the full v2 response (including extra fields),
- Supports optionally verifying the `hostname` and `action` in `Verify2Async` (`action` isn't returned by Google, but is by Cloudflare),
- Has unit tests for everything,
- Adds constants for Cloudflare Turnstile support,
- Adds instructions for using Cloudflare Turnstile in the readme.